### PR TITLE
Add doctors table migration and Doctor model

### DIFF
--- a/app/Models/Doctor.php
+++ b/app/Models/Doctor.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Doctor extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'first_name',
+        'last_name',
+        'crm',
+        'crm_uf',
+        'specialty',
+        'email',
+        'phone',
+        'whatsapp',
+        'bio',
+        'is_active',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'is_active' => 'boolean',
+    ];
+
+    /**
+     * Get the doctor's full name.
+     */
+    public function getFullNameAttribute(): string
+    {
+        return trim($this->first_name . ' ' . $this->last_name);
+    }
+}

--- a/database/migrations/2025_09_15_000001_create_doctors_table.php
+++ b/database/migrations/2025_09_15_000001_create_doctors_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('doctors', function (Blueprint $table) {
+            $table->id();
+            $table->string('first_name');
+            $table->string('last_name');
+            $table->string('crm', 20)->unique();
+            $table->string('crm_uf', 2);
+            $table->string('specialty')->nullable();
+            $table->string('email')->unique();
+            $table->string('phone', 20)->nullable();
+            $table->string('whatsapp', 20)->nullable();
+            $table->text('bio')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('doctors');
+    }
+};


### PR DESCRIPTION
## Summary
- add a migration to create the doctors table with CRM, contact, and profile fields
- introduce the Doctor Eloquent model with fillable attributes, casts, and a full-name accessor

## Testing
- `php artisan migrate` *(fails: Could not open input file: artisan)*

------
https://chatgpt.com/codex/tasks/task_e_68c86c4d9e988333982384d9413645f3