### PR TITLE
Add patients table migration and model

### DIFF
--- a/app/Models/Patient.php
+++ b/app/Models/Patient.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Patient extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'first_name',
+        'last_name',
+        'birth_date',
+        'gender',
+        'cpf',
+        'email',
+        'phone',
+        'whatsapp',
+        'emergency_contact_name',
+        'emergency_contact_phone',
+        'blood_type',
+        'allergies',
+        'medical_conditions',
+        'medications',
+        'notes',
+        'has_insurance',
+        'insurance_provider',
+        'insurance_policy_number',
+        'is_active',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'birth_date' => 'date',
+        'has_insurance' => 'boolean',
+        'is_active' => 'boolean',
+    ];
+
+    /**
+     * Get the patient's full name.
+     */
+    public function getFullNameAttribute(): string
+    {
+        return trim($this->first_name . ' ' . $this->last_name);
+    }
+}

--- a/database/migrations/2025_09_15_000002_create_patients_table.php
+++ b/database/migrations/2025_09_15_000002_create_patients_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('patients', function (Blueprint $table) {
+            $table->id();
+            $table->string('first_name');
+            $table->string('last_name');
+            $table->date('birth_date')->nullable();
+            $table->string('gender', 20)->nullable();
+            $table->string('cpf', 14)->unique();
+            $table->string('email')->unique();
+            $table->string('phone', 20)->nullable();
+            $table->string('whatsapp', 20)->nullable();
+            $table->string('emergency_contact_name')->nullable();
+            $table->string('emergency_contact_phone', 20)->nullable();
+            $table->string('blood_type', 3)->nullable();
+            $table->text('allergies')->nullable();
+            $table->text('medical_conditions')->nullable();
+            $table->text('medications')->nullable();
+            $table->text('notes')->nullable();
+            $table->boolean('has_insurance')->default(false);
+            $table->string('insurance_provider')->nullable();
+            $table->string('insurance_policy_number')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('patients');
+    }
+};


### PR DESCRIPTION
## Summary
- add a patients table migration with personal, contact, and insurance fields
- introduce the Patient Eloquent model with fillable attributes, casts, and a full name accessor

## Testing
- `php artisan migrate` *(fails: Could not open input file: artisan)*

------
https://chatgpt.com/codex/tasks/task_e_68c86e04207483338981d1a335930020