### PR TITLE
Add encounters migration and model

### DIFF
--- a/app/Models/Doctor.php
+++ b/app/Models/Doctor.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Doctor extends Model
 {
@@ -42,5 +43,13 @@ class Doctor extends Model
     public function getFullNameAttribute(): string
     {
         return trim($this->first_name . ' ' . $this->last_name);
+    }
+
+    /**
+     * Get the encounters associated with the doctor.
+     */
+    public function encounters(): HasMany
+    {
+        return $this->hasMany(Encounter::class);
     }
 }

--- a/app/Models/Encounter.php
+++ b/app/Models/Encounter.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Encounter extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'doctor_id',
+        'patient_first_name',
+        'patient_last_name',
+        'patient_birth_date',
+        'patient_gender',
+        'patient_email',
+        'patient_phone',
+        'scheduled_at',
+        'encounter_type',
+        'status',
+        'duration_minutes',
+        'requires_follow_up',
+        'follow_up_at',
+        'reason',
+        'notes',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'patient_birth_date' => 'date',
+        'scheduled_at' => 'datetime',
+        'follow_up_at' => 'datetime',
+        'requires_follow_up' => 'boolean',
+        'duration_minutes' => 'integer',
+    ];
+
+    /**
+     * Get the doctor responsible for the encounter.
+     */
+    public function doctor(): BelongsTo
+    {
+        return $this->belongsTo(Doctor::class);
+    }
+}

--- a/database/migrations/2025_09_15_000002_create_encounters_table.php
+++ b/database/migrations/2025_09_15_000002_create_encounters_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('encounters', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('doctor_id')->constrained()->cascadeOnDelete();
+            $table->string('patient_first_name');
+            $table->string('patient_last_name')->nullable();
+            $table->date('patient_birth_date')->nullable();
+            $table->string('patient_gender', 20)->nullable();
+            $table->string('patient_email')->nullable();
+            $table->string('patient_phone', 20)->nullable();
+            $table->dateTime('scheduled_at');
+            $table->string('encounter_type', 50)->default('in_person');
+            $table->string('status', 50)->default('scheduled');
+            $table->integer('duration_minutes')->nullable();
+            $table->boolean('requires_follow_up')->default(false);
+            $table->dateTime('follow_up_at')->nullable();
+            $table->text('reason')->nullable();
+            $table->text('notes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('encounters');
+    }
+};


### PR DESCRIPTION
## Summary
- add a migration that defines the encounters table with patient and scheduling metadata
- create the Encounter Eloquent model with mass-assignment configuration, casts, and doctor relationship
- expose a has-many relationship on Doctor to access related encounters

## Testing
- `php artisan migrate` *(fails: Could not open input file: artisan)*


------
https://chatgpt.com/codex/tasks/task_e_68c8d18a659c8333816482029d89830e