### PR TITLE
Add logs table migration and LogEntry model

### DIFF
--- a/app/Models/LogEntry.php
+++ b/app/Models/LogEntry.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class LogEntry extends Model
+{
+    use HasFactory;
+
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'logs';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'event',
+        'level',
+        'message',
+        'context',
+        'performed_by',
+        'ip_address',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'context' => 'array',
+    ];
+
+    /**
+     * Determine if the log entry was created for a specific user.
+     */
+    public function hasPerformer(): bool
+    {
+        return ! empty($this->performed_by);
+    }
+}

--- a/database/migrations/2025_09_15_000002_create_logs_table.php
+++ b/database/migrations/2025_09_15_000002_create_logs_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('logs', function (Blueprint $table) {
+            $table->id();
+            $table->string('event');
+            $table->string('level')->default('info');
+            $table->text('message')->nullable();
+            $table->json('context')->nullable();
+            $table->string('performed_by')->nullable();
+            $table->string('ip_address', 45)->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('logs');
+    }
+};


### PR DESCRIPTION
## Summary
- add a migration that creates a logs table capturing event metadata, message details, and performer info
- introduce a LogEntry model bound to the logs table with fillable fields and JSON casting

## Testing
- php artisan migrate *(fails: artisan script is not present in the provided project skeleton)*

------
https://chatgpt.com/codex/tasks/task_e_68c8d1914b408333bbac6b0e07acccf8